### PR TITLE
scripts: fix libpython.dynamic on macOS

### DIFF
--- a/python_introspection/scripts/generate-build-details.py
+++ b/python_introspection/scripts/generate-build-details.py
@@ -95,12 +95,12 @@ def generate_data(schema_version):
                 data['abi']['stable_abi_suffix'] = suffix
                 break
 
-        data['libpython']['dynamic'] = os.path.join(LIBDIR, LDLIBRARY)
-        if not os.path.exists(data['libpython']['dynamic']):
-            # macOS has a different location
-            PYTHONFRAMEWORKPREFIX = sysconfig.get_config_var('PYTHONFRAMEWORKPREFIX')
-            if os.path.exists(os.path.join(PYTHONFRAMEWORKPREFIX, LDLIBRARY)):
-                data['libpython']['dynamic'] = os.path.join(PYTHONFRAMEWORKPREFIX, LDLIBRARY)
+        PYTHONFRAMEWORKPREFIX = sysconfig.get_config_var('PYTHONFRAMEWORKPREFIX')
+        if PYTHONFRAMEWORKPREFIX:
+            # macOS framework builds have a custom location
+            data['libpython']['dynamic'] = os.path.join(PYTHONFRAMEWORKPREFIX, LDLIBRARY)
+        else:
+            data['libpython']['dynamic'] = os.path.join(LIBDIR, LDLIBRARY)
 
         # FIXME: Not sure if windows has a different dll for the stable ABI, and
         #        even if it does, currently we don't have a way to get its name.

--- a/python_introspection/scripts/generate-build-details.py
+++ b/python_introspection/scripts/generate-build-details.py
@@ -96,6 +96,12 @@ def generate_data(schema_version):
                 break
 
         data['libpython']['dynamic'] = os.path.join(LIBDIR, LDLIBRARY)
+        if not os.path.exists(data['libpython']['dynamic']):
+            # macOS has a different location
+            PYTHONFRAMEWORKPREFIX = sysconfig.get_config_var('PYTHONFRAMEWORKPREFIX')
+            if os.path.exists(os.path.join(PYTHONFRAMEWORKPREFIX, LDLIBRARY)):
+                data['libpython']['dynamic'] = os.path.join(PYTHONFRAMEWORKPREFIX, LDLIBRARY)
+
         # FIXME: Not sure if windows has a different dll for the stable ABI, and
         #        even if it does, currently we don't have a way to get its name.
         if PY3LIBRARY:


### PR DESCRIPTION
/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13/Python is the actual location of whatever LDLIBRARY is returning.

```
>>> sysconfig.get_config_var('LIBDIR')
'/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13/lib'
>>> sysconfig.get_config_var('LDLIBRARY')
'Python.framework/Versions/3.13/Python
```

So joining those two is incorrect.

```
>>> sysconfig.get_config_var('PYTHONFRAMEWORKPREFIX')
'/opt/homebrew/opt/python@3.13/Frameworks'
```

Is the correct prefix.

It's possible that /opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13/lib/libpython3.13.dylib is the intended target (it has the same md5sum as the file listed above), but there are no dylibs listed in the sysconfig data as far as I can see.