### PR TITLE
scripts: make base executable optional and prefer EXENAME over sys._base_executable

### DIFF
--- a/python_introspection/scripts/generate-build-details.py
+++ b/python_introspection/scripts/generate-build-details.py
@@ -38,7 +38,11 @@ def generate_data(schema_version):
     data['schema_version'] = schema_version
 
     data['base_prefix'] = sysconfig.get_config_var('installed_base')
-    data['base_interpreter'] = sys._base_executable
+
+    base_interpreter = sysconfig.get_config_var('EXENAME') or getattr(sys, '_base_executable', None)
+    if base_interpreter:
+        data['base_interpreter'] = base_interpreter
+
     data['platform'] = sysconfig.get_platform()
 
     data['language']['version'] = sysconfig.get_python_version()


### PR DESCRIPTION
This gives me better results on macOS. Neither are documented so it's not clear there's a reason to prefer one over the other.

```
>>> sys.base_prefix
'/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13'
>>> sysconfig.get_config_var("EXENAME")
'/opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13/bin/python3.13'
>>> sys._base_executable
'/opt/homebrew/opt/python@3.13/bin/python3.13'
```

```
% md5sum /opt/homebrew/opt/python@3.13/bin/python3.13
f30440b12a36df17073ee987c5249e5d  /opt/homebrew/opt/python@3.13/bin/python3.13
% md5sum /opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13/bin/python3.13
f30440b12a36df17073ee987c5249e5d  /opt/homebrew/opt/python@3.13/Frameworks/Python.framework/Versions/3.13/bin/python3.13
```