### PR TITLE
scripts: fix crash on warnings

### DIFF
--- a/python_introspection/scripts/generate-build-details.py
+++ b/python_introspection/scripts/generate-build-details.py
@@ -203,7 +203,7 @@ def main():  # () -> None
         'warnings': [
             {
                 'message': str(warning.message),
-                'category': '.'.join(warning.category.__module__, warning.category.__qualname__),
+                'category': '.'.join((warning.category.__module__, warning.category.__qualname__)),
                 'filename': warning.filename,
                 'lineno': warning.lineno,
             }


### PR DESCRIPTION
Fix incorrectly passing two arguments to `str.join()` that caused crash when the script output any warning (e.g. with Python 3.14).