### PR TITLE
main: fix `--output` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ $ python -m python_introspection (options) <command> ...
 Option                 | Description
 ---------------------- | -------------------------------------------------------
 `--interpreter <path>` | Selects the Python interpreter to instrospect.
-`--write-to <path>`    | Write introspection data to the specified file.
+`--output <path>`      | Write introspection data to the specified file.
 
 
 ### `generate-build-details`
@@ -40,3 +40,10 @@ Option                 | Description
 -------------------------- | ---------------------------------------------------
 `--schema-version <value>` | Schema version of the build-details.json file to generate.
 `--relative-paths`         | Whether to specify paths as absolute, or as relative paths to `base_prefix`.
+
+
+A full example, putting together the base `--interpreter` and `--output` options with
+the options to `generate-build-details`:
+```sh
+$ python -m python_introspection --interpreter $(which python) --output build-details.json generate-build-details --relative-paths
+```

--- a/python_introspection/__main__.py
+++ b/python_introspection/__main__.py
@@ -54,11 +54,12 @@ def main() -> None:
         )
     assert data
 
-    json_data = json.dumps(data, indent=2)
     if args.output:
-        args.parent.mkdir(parents=True, exist_ok=True)
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        with open(args.output, 'w') as f:
+            json.dump(data, f, ensure_ascii=False, indent=2)
     else:
-        print(json_data)
+        print(json.dumps(data, ensure_ascii=False, indent=2))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Writing to a file with `--output` was broken, and the docs called the option `--write-to` instead of `--output`.